### PR TITLE
replace old census gem with a new census gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,12 +16,11 @@ gem "figaro"
 gem "faraday"
 gem 'awesome_print'
 gem 'faker'
-gem "faraday"
 
 gem 'omniauth-oauth2'
+gem 'omniauth-census', git: 'https://github.com/AELSchauer/omniauth-census', branch: 'env'
 
 group :development, :test do
-  gem 'omniauth-census', git: "https://github.com/NZenitram/census_staging_oauth"
   gem 'thin'
   gem 'byebug'
   gem 'rspec-rails', '~> 3.5'
@@ -34,10 +33,6 @@ group :development, :test do
   gem 'capybara'
   gem 'launchy'
   gem 'selenium-webdriver'
-end
-
-group :production do
-  gem 'omniauth-census-production', git: "https://github.com/AELSchauer/census_production_oauth"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,7 @@
 GIT
-  remote: https://github.com/AELSchauer/census_production_oauth
-  revision: 3580f1aca9c64b6779b99e6f5940fa9cd2fc97b5
-  specs:
-    omniauth-census-production (0.1.1)
-      omniauth-oauth2
-
-GIT
-  remote: https://github.com/NZenitram/census_staging_oauth
-  revision: 082f9c376dd85e6d65415f8d1dac0e054971433c
+  remote: https://github.com/AELSchauer/omniauth-census
+  revision: 4e335dbe86bb4a4d8410a897fdb5175aed1491af
+  branch: env
   specs:
     omniauth-census (0.1.1)
       omniauth-oauth2
@@ -283,7 +277,6 @@ DEPENDENCIES
   jquery-ui-rails
   launchy
   omniauth-census!
-  omniauth-census-production!
   omniauth-oauth2
   pg (~> 0.15)
   poltergeist

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -19,7 +19,7 @@ class Seed
 
   def get_all_census_users
     this = Faraday.get("https://census-app-staging.herokuapp.com/api/v1/users/?access_token=#{ENV['CENSUS_ACCESS_TOKEN']}")
-    response = JSON.parse(this.body, symbolize_names: true)
+    this.body.empty? ? [] : JSON.parse(this.body, symbolize_names: true)
   end
 
   def find_mentors


### PR DESCRIPTION
This replaces our old gem setup for census omniauth with a new gem that automatically directs you to staging vs production census by the rails environment. 