### PR TITLE
updates edit page so info from census isn't editable within the app

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,10 +16,9 @@ gem "figaro"
 gem "faraday"
 gem 'awesome_print'
 gem 'faker'
-gem "faraday"
 
 gem 'omniauth-oauth2'
-gem 'omniauth-census', git: "https://github.com/NZenitram/census_staging_oauth"
+gem 'omniauth-census', git: 'https://github.com/AELSchauer/omniauth-census', branch: 'env'
 
 group :development, :test do
   gem 'thin'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GIT
-  remote: https://github.com/NZenitram/census_staging_oauth
-  revision: 082f9c376dd85e6d65415f8d1dac0e054971433c
+  remote: https://github.com/AELSchauer/omniauth-census
+  revision: 4e335dbe86bb4a4d8410a897fdb5175aed1491af
+  branch: env
   specs:
     omniauth-census (0.1.1)
       omniauth-oauth2

--- a/app/assets/javascripts/components/edit/_edit.js.jsx
+++ b/app/assets/javascripts/components/edit/_edit.js.jsx
@@ -52,11 +52,6 @@ var Edit = React.createClass({
     var position = this.state.position;
     var location = this.state.location;
     var expertise = this.state.expertise;
-    var first_name = this.state.first_name;
-    var last_name = this.state.last_name;
-    var slack = this.state.slack;
-    var email = this.state.email;
-
 
     var updatedInfo = {bio: bio, company: company, position: position, location: location, expertise: expertise, first_name: first_name, last_name: last_name, slack: slack, email: email }
     this.handleUpdate(updatedInfo);
@@ -82,31 +77,44 @@ var Edit = React.createClass({
               </div>
               <div className="col s6">
                 <div className="form-area">
+                  <div className="censusInformation">
+                    <table>
+                      <tbody>
+                        <tr>
+                          <td><h6 className="edit-headers">First Name:</h6></td>
+                          <td><a href={mentor.account_url} target="_blank">{mentor.first_name}</a></td>
+                        </tr>
+                        <tr>
+                          <td><h6 className="edit-headers">Last Name:</h6></td>
+                          <td><a href={mentor.account_url} target="_blank">{mentor.last_name}</a></td>
+                        </tr>
+                        <tr>
+                          <td><h6 className="edit-headers">Slack:</h6></td>
+                          <td><a href={mentor.account_url} target="_blank">{mentor.slack}</a></td>
+                        </tr>
+                        <tr>
+                          <td><h6 className="edit-headers">Email:</h6></td>
+                          <td><a href={mentor.account_url} target="_blank">{mentor.email}</a></td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </div>
                   <div className="container-form">
-                    <h6><span className="edit-headers">First Name:</span></h6>
-                    <input type='text' className="inputField census-data" onChange={ (e) => this.setState({ first_name: e.target.value }) }
-                     placeholder={mentor.first_name} />
-                    <h6><span className="edit-headers">Last Name:</span></h6>
-                    <input type='text' className="inputField census-data" onChange={ (e) => this.setState({ last_name: e.target.value }) } placeholder={mentor.last_name} />
-                    <h6><span className="edit-headers">Slack:</span></h6>
-                    <input type='text' className="inputField census-data" onChange={ (e) => this.setState({ slack: e.target.value }) } placeholder={mentor.slack} />
-                    <h6><span className="edit-headers">Email:</span></h6>
-                    <input type='text' className="inputField census-data" onChange={ (e) => this.setState({ email: e.target.value }) } placeholder={mentor.email} />
                     <h6><span className="edit-headers">Bio:</span></h6>
-                    <input id="bioField" type='text' className="inputField" onKeyUp={this.checkValues} onChange={ (e) => this.setState({ bio: e.target.value }) }
-                      placeholder="Please Enter Your Information To Accept Mentees" />
+                    <input id="bioField" type='text' className="inputField" cols='50' rows='10' onKeyUp={this.checkValues} onChange={ (e) => this.setState({ bio: e.target.value }) }
+                      placeholder="Please Enter Your Information To Accept Mentees" value={mentor.bio} />
                     <h6><span className="edit-headers">Company:</span></h6>
                     <input id="companyField" type='text' className="inputField" onKeyUp={this.checkValues} onChange={ (e) => this.setState({ company: e.target.value }) }
-                      placeholder="Please Enter Your Information To Accept Mentees" />
+                      placeholder="Please Enter Your Information To Accept Mentees" value={mentor.company} />
                     <h6><span className="edit-headers">Position:</span></h6>
                     <input id="positionField" type='text' className="inputField" onKeyUp={this.checkValues} onChange={ (e) => this.setState({ position: e.target.value }) }
-                      placeholder="Please Enter Your Information To Accept Mentees" />
+                      placeholder="Please Enter Your Information To Accept Mentees" value={mentor.position} />
                     <h6><span className="edit-headers">Location:</span></h6>
                     <input id="locationField" type='text' className="inputField" onKeyUp={this.checkValues} onChange={ (e) => this.setState({ location: e.target.value }) }
-                      placeholder="Please Enter Your Information To Accept Mentees" />
+                      placeholder="Please Enter Your Information To Accept Mentees" value={mentor.location} />
                     <h6><span className="edit-headers">Expertise:</span></h6>
                     <input id="expertiseField" type='text' className="inputField" onKeyUp={this.checkValues} onChange={ (e) => this.setState({ expertise: e.target.value }) }
-                      placeholder="Please Enter Your Information To Accept Mentees" />
+                      placeholder="Please Enter Your Information To Accept Mentees" value={mentor.expertise} />
                   </div>
                 </div>
                   <div className="edit-submit-button"><button onClick={this.handleEdit}> Submit </button></div>

--- a/app/assets/stylesheets/application.css.erb
+++ b/app/assets/stylesheets/application.css.erb
@@ -31,6 +31,11 @@ h1 {
   padding-left: 100px;
 }
 
+td > h6 {
+  padding-top: 0px;
+  margin: 0px;
+}
+
 #header-about {
   text-align: center;
   color: black;
@@ -156,7 +161,6 @@ h6 {
   font-weight: bolder;
   text-shadow: 1px 1px 1px #000;
   padding-left: 10px;
-  padding-top: 100px;
 }
 
 #location-show-header {

--- a/app/controllers/api/v1/mentors_controller.rb
+++ b/app/controllers/api/v1/mentors_controller.rb
@@ -6,9 +6,9 @@ class Api::V1::MentorsController < Api::V1::BaseController
   end
 
   def show
-    user = User.find(params[:id])
+    mentor = Mentor.find_or_create_by(user: params[:id])
 
-    render json: user.mentor_profile
+    render json: mentor.profile
   end
 
   def update

--- a/app/controllers/api/v1/mentors_controller.rb
+++ b/app/controllers/api/v1/mentors_controller.rb
@@ -6,7 +6,9 @@ class Api::V1::MentorsController < Api::V1::BaseController
   end
 
   def show
-    render json: Mentor.find(params[:id])
+    user = User.find(params[:id])
+
+    render json: user.mentor_profile
   end
 
   def update
@@ -31,5 +33,4 @@ class Api::V1::MentorsController < Api::V1::BaseController
   def census_params
     params.require(:user).permit(:first_name, :last_name, :slack, :email)
   end
-
 end

--- a/app/models/census_profile.rb
+++ b/app/models/census_profile.rb
@@ -1,6 +1,6 @@
-class CensusProfile 
+class CensusProfile
 
-  attr_reader :slack, :email, :first_name, :last_name, :avatar, :cohort
+  attr_reader :slack, :email, :first_name, :last_name, :avatar, :cohort, :id
 
   def initialize(user_hash)
     @slack = user_hash[:slack]
@@ -9,11 +9,16 @@ class CensusProfile
     @last_name = user_hash[:last_name]
     @avatar = user_hash[:image_url]
     @cohort = user_hash[:cohort]
+    @id = user_hash[:id]
   end
 
   def self.find(id, token)
     user_hash = CensusService.new(token).get_user(id)
     CensusProfile.new(user_hash)
+  end
+
+  def account_url
+    "#{ENV['CENSUS_URL']}/users/#{id}"
   end
 
 end

--- a/app/models/mentor.rb
+++ b/app/models/mentor.rb
@@ -14,6 +14,20 @@ class Mentor < ApplicationRecord
            :bio,
            :census_id,
            :token,
+           :account_url,
            :last_active, to: :user
+
+
+  def profile
+    attr_list = [
+      :account_url, :active, :avatar, :bio, :company, :email,
+      :expertise, :first_name, :gender, :last_name, :location,
+      :position, :profile_complete, :slack
+    ]
+
+    attr_list.reduce({}) do |profile, attr|
+      profile.merge!({attr => self.send(attr)})
+    end
+  end
 
 end

--- a/app/models/mentor.rb
+++ b/app/models/mentor.rb
@@ -14,7 +14,6 @@ class Mentor < ApplicationRecord
            :bio,
            :census_id,
            :token,
-           :gender,
            :last_active, to: :user
 
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,33 +3,15 @@ class User < ApplicationRecord
   has_one :mentor
 
   delegate :avatar,
-          :first_name,
-          :last_name,
-          :email,
-          :slack,
-          :cohort, to: :census_profile
+           :first_name,
+           :last_name,
+           :email,
+           :slack,
+           :account_url,
+           :cohort, to: :census_profile
 
   def census_profile
     token = ENV['CENSUS_ACCESS_TOKEN']
     @census_profile ||= CensusProfile.find(census_id, token)
   end
-
-
-  def mentor_profile
-    Mentor.create(user: self) if self.mentor.nil?
-
-    directory = {
-      mentor => [:expertise, :company, :position, :active, :profile_complete, :gender, :location],
-      census_profile => [:avatar, :email, :first_name, :last_name, :slack, :account_url],
-      self => [:bio]
-    }
-
-    directory.reduce({}) do |profile, (user_class, attr_list)|
-      attr_list.each do |attr|
-        profile[attr] = user_class.send(attr)
-      end
-      profile
-    end
-  end
-
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,4 +14,22 @@ class User < ApplicationRecord
     @census_profile ||= CensusProfile.find(census_id, token)
   end
 
+
+  def mentor_profile
+    Mentor.create(user: self) if self.mentor.nil?
+
+    directory = {
+      mentor => [:expertise, :company, :position, :active, :profile_complete, :gender, :location],
+      census_profile => [:avatar, :email, :first_name, :last_name, :slack, :account_url],
+      self => [:bio]
+    }
+
+    directory.reduce({}) do |profile, (user_class, attr_list)|
+      attr_list.each do |attr|
+        profile[attr] = user_class.send(attr)
+      end
+      profile
+    end
+  end
+
 end

--- a/app/services/census_service.rb
+++ b/app/services/census_service.rb
@@ -1,7 +1,7 @@
 class CensusService
 
   def initialize(token)
-    url = ENV["CENSUS_URL"]
+    url = "#{ENV["CENSUS_URL"]}/api/v1"
 
     @conn = Faraday.new(url: url) do |faraday|
       faraday.adapter  Faraday.default_adapter

--- a/app/services/census_service.rb
+++ b/app/services/census_service.rb
@@ -3,9 +3,8 @@ class CensusService
   def initialize(token)
     url = "https://census-app-staging.herokuapp.com/api/v1/" if Rails.env != "production"
     url = "https://turing-census.herokuapp.com/api/v1/" if Rails.env == "production"
-    
+
     @conn = Faraday.new(url: url) do |faraday|
-    
       faraday.adapter  Faraday.default_adapter
       faraday.params[:access_token] = token
     end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -18,7 +18,7 @@ class Seed
   end
 
   def get_all_census_users
-    this = Faraday.get("#{ENV['CENSUS_URL']}users/?access_token=#{ENV['CENSUS_ACCESS_TOKEN']}")
+    this = Faraday.get("#{ENV['CENSUS_URL']}/api/v1/users/?access_token=#{ENV['CENSUS_ACCESS_TOKEN']}")
     this.body.empty? ? [] : JSON.parse(this.body, symbolize_names: true)
   end
 


### PR DESCRIPTION
- Updates page where user can update their mentor profile so that attributes from census cannot be edited.
-Adds a link to census attributes that opens a new tab on the census page for the user to update those details there.
-Submit button has not been tested. That will be in another PR from @blackknight75 .
-The attributes for the mentor profile page are pulled from three different classes. Behind the scenes, I create a method on the user class to compile all these into a hash for the api/v1/mentors/ show endpoint.
- Also changes the 'CENSUS_URL' environment variable so it calls for the site root rather than the API root. This allows me to build the 'account_url' method on the CensusProfile model.