### PR TITLE
Change mentor location from Timezone table to Google API look up and Timezone gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,8 @@ gem "figaro"
 gem "faraday"
 gem 'awesome_print'
 gem 'faker'
+gem 'geokit'
+gem 'timezone'
 
 gem 'omniauth-oauth2'
 gem 'omniauth-census', git: "https://github.com/AELSchauer/omniauth-census", branch: "env"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,7 @@ GEM
     ffi (1.9.17)
     figaro (1.1.1)
       thor (~> 0.14)
+    geokit (1.11.0)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     hashie (3.5.1)
@@ -244,6 +245,7 @@ GEM
     thor (0.19.4)
     thread_safe (0.3.5)
     tilt (2.0.6)
+    timezone (1.2.7)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uglifier (3.0.4)
@@ -273,6 +275,7 @@ DEPENDENCIES
   faker
   faraday
   figaro
+  geokit
   jquery-rails
   jquery-ui-rails
   launchy
@@ -292,6 +295,7 @@ DEPENDENCIES
   shoulda-matchers (~> 3.1)
   simplecov
   thin
+  timezone
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
 

--- a/app/assets/javascripts/components/edit/_edit.js.jsx
+++ b/app/assets/javascripts/components/edit/_edit.js.jsx
@@ -3,11 +3,9 @@ var Edit = React.createClass({
     var bio = document.getElementById('bioField').value;
     var company = document.getElementById('companyField').value;
     var position = document.getElementById('positionField').value;
-    var city = document.getElementById('cityField').value;
-    var state = document.getElementById('stateField').value;
-    var country = document.getElementById('countryField').value;
+    var location = document.getElementById('locationField').value;
     var expertise = document.getElementById('expertiseField').value;
-    if ([bio, company, position, city, expertise].includes("") === false && !(state == "" && country == "")) {
+    if (([bio, company, position, location, expertise].includes("")) === false) {
       this.buttonStatus();
     }
   },
@@ -43,7 +41,7 @@ var Edit = React.createClass({
     $.ajax({
      url: `/api/v1/mentors/${mentor.id}`,
      type: 'PATCH',
-     data: { user: { bio: updatedInfo.bio, company: updatedInfo.company, position: updatedInfo.position, city: updatedInfo.city, state: updatedInfo.state, country: updatedInfo.country } },
+     data: { user: { bio: updatedInfo.bio, company: updatedInfo.company, position: updatedInfo.position, location: updatedInfo.location, expertise: updatedInfo.expertise } },
      success: function(){ window.location = "/mentors"; }
    });
   },
@@ -53,12 +51,10 @@ var Edit = React.createClass({
     var bio = this.state.mentor.bio;
     var company = this.state.mentor.company;
     var position = this.state.mentor.position;
-    var city = this.state.mentor.city;
-    var state = this.state.mentor.state;
-    var country = this.state.mentor.country;
+    var location = this.state.mentor.location;
     var expertise = this.state.mentor.expertise;
 
-    var updatedInfo = { bio: bio, company: company, position: position, city: city, state: state, country: country, expertise: expertise }
+    var updatedInfo = { bio: bio, company: company, position: position, location: location, expertise: expertise }
     this.handleUpdate(updatedInfo);
   },
 
@@ -147,15 +143,8 @@ var Edit = React.createClass({
                     <input id="companyField" type='text' className="inputField" onKeyUp={this.checkValues} onChange={ (e) => this.handleCompanyChange(e) } value={mentor.company} />
                     <h6><span className="edit-headers">Position:</span></h6>
                     <input id="positionField" type='text' className="inputField" onKeyUp={this.checkValues} onChange={ (e) => this.handlePositionChange(e) } value={mentor.position} />
-                    <h6><span className="edit-headers">City:</span></h6>
-                    <input id="cityField" type='text' className="inputField" onKeyUp={this.checkValues} onChange={ (e) => this.setState({ city: e.target.value }) }
-                      placeholder="Please Enter Your Information To Accept Mentees" value={mentor.city} />
-                    <h6><span className="edit-headers">State:</span></h6>
-                    <input id="stateField" type='text' className="inputField" onKeyUp={this.checkValues} onChange={ (e) => this.setState({ state: e.target.value }) }
-                      placeholder="Please Enter Your Information To Accept Mentees" value={mentor.state} />
-                    <h6><span className="edit-headers">Country:</span></h6>
-                    <input id="countryField" type='text' className="inputField" onKeyUp={this.checkValues} onChange={ (e) => this.setState({ country: e.target.value }) }
-                      placeholder="Please Enter Your Information To Accept Mentees" value={mentor.country} />
+                    <h6><span className="edit-headers">Location:</span></h6>
+                    <input id="locationField" type='text' className="inputField" onKeyUp={this.checkValues} onChange={ (e) => this.handleLocationChange(e) } value={mentor.location} placeholder="City, State, Country"/>
                     <h6><span className="edit-headers">Expertise:</span></h6>
                     <input id="expertiseField" type='text' className="inputField" onKeyUp={this.checkValues} onChange={ (e) => this.handleExpertiseChange(e) } value={mentor.expertise} />
                   </div>

--- a/app/assets/javascripts/components/edit/_edit.js.jsx
+++ b/app/assets/javascripts/components/edit/_edit.js.jsx
@@ -3,9 +3,11 @@ var Edit = React.createClass({
     var bio = document.getElementById('bioField').value;
     var company = document.getElementById('companyField').value;
     var position = document.getElementById('positionField').value;
-    var location = document.getElementById('locationField').value;
+    var city = document.getElementById('cityField').value;
+    var state = document.getElementById('stateField').value;
+    var country = document.getElementById('countryField').value;
     var expertise = document.getElementById('expertiseField').value;
-    if (([bio, company, position, location, expertise].includes("")) === false) {
+    if ([bio, company, position, city, expertise].includes("") === false && !(state == "" && country == "")) {
       this.buttonStatus();
     }
   },
@@ -41,7 +43,7 @@ var Edit = React.createClass({
     $.ajax({
      url: `/api/v1/mentors/${mentor.id}`,
      type: 'PATCH',
-     data: {user: { bio: updatedInfo.bio, company: updatedInfo.company, position: updatedInfo.position, location: updatedInfo.location, expertise: updatedInfo.expertise, first_name: updatedInfo.first_name, last_name: updatedInfo.last_name, email: updatedInfo.email, slack: updatedInfo.slack }},
+     data: { user: { bio: updatedInfo.bio, company: updatedInfo.company, position: updatedInfo.position, city: updatedInfo.city, state: updatedInfo.state, country: updatedInfo.country } },
      success: function(){ window.location = "/mentors"; }
    });
   },
@@ -51,10 +53,12 @@ var Edit = React.createClass({
     var bio = this.state.bio;
     var company = this.state.company;
     var position = this.state.position;
-    var location = this.state.location;
+    var city = this.state.city;
+    var state = this.state.state;
+    var country = this.state.country;
     var expertise = this.state.expertise;
 
-    var updatedInfo = {bio: bio, company: company, position: position, location: location, expertise: expertise, first_name: first_name, last_name: last_name, slack: slack, email: email }
+    var updatedInfo = { bio: bio, company: company, position: position, city: city, state: state, country: country, expertise: expertise }
     this.handleUpdate(updatedInfo);
   },
 
@@ -110,9 +114,15 @@ var Edit = React.createClass({
                     <h6><span className="edit-headers">Position:</span></h6>
                     <input id="positionField" type='text' className="inputField" onKeyUp={this.checkValues} onChange={ (e) => this.setState({ position: e.target.value }) }
                       placeholder="Please Enter Your Information To Accept Mentees" value={mentor.position} />
-                    <h6><span className="edit-headers">Location:</span></h6>
-                    <input id="locationField" type='text' className="inputField" onKeyUp={this.checkValues} onChange={ (e) => this.setState({ location: e.target.value }) }
-                      placeholder="Please Enter Your Information To Accept Mentees" value={mentor.location} />
+                    <h6><span className="edit-headers">City:</span></h6>
+                    <input id="cityField" type='text' className="inputField" onKeyUp={this.checkValues} onChange={ (e) => this.setState({ city: e.target.value }) }
+                      placeholder="Please Enter Your Information To Accept Mentees" value={mentor.city} />
+                    <h6><span className="edit-headers">State:</span></h6>
+                    <input id="stateField" type='text' className="inputField" onKeyUp={this.checkValues} onChange={ (e) => this.setState({ state: e.target.value }) }
+                      placeholder="Please Enter Your Information To Accept Mentees" value={mentor.state} />
+                    <h6><span className="edit-headers">Country:</span></h6>
+                    <input id="countryField" type='text' className="inputField" onKeyUp={this.checkValues} onChange={ (e) => this.setState({ country: e.target.value }) }
+                      placeholder="Please Enter Your Information To Accept Mentees" value={mentor.country} />
                     <h6><span className="edit-headers">Expertise:</span></h6>
                     <input id="expertiseField" type='text' className="inputField" onKeyUp={this.checkValues} onChange={ (e) => this.setState({ expertise: e.target.value }) }
                       placeholder="Please Enter Your Information To Accept Mentees" value={mentor.expertise} />

--- a/app/assets/javascripts/components/edit/_edit.js.jsx
+++ b/app/assets/javascripts/components/edit/_edit.js.jsx
@@ -84,7 +84,7 @@ var Edit = React.createClass({
 
   handleExpertiseChange(e) {
     let mentor = this.state.mentor;
-    mentor.expertiseField = e.target.value;
+    mentor.expertise = e.target.value;
     this.setMentorChange(mentor)
   },
 

--- a/app/assets/javascripts/components/mentors/_body.js.jsx
+++ b/app/assets/javascripts/components/mentors/_body.js.jsx
@@ -5,7 +5,12 @@ var Body = React.createClass({
   },
 
   componentDidMount() {
-    $.getJSON('/api/v1/mentors.json', (response) => { this.setState({ mentors: response, allMentors: response }) });
+    $.getJSON('/api/v1/mentors.json', (response) => {
+      this.setState({ mentors: response, allMentors: response })
+    })
+    .fail( (failure) => {
+      console.log(failure)
+    })
   },
 
   searchMentors(query){

--- a/app/controllers/api/v1/mentors_controller.rb
+++ b/app/controllers/api/v1/mentors_controller.rb
@@ -15,7 +15,7 @@ class Api::V1::MentorsController < Api::V1::BaseController
     user.update(user_params)
     mentor = Mentor.find_or_create_by(user_id: params[:id])
     mentor.update(mentor_params)
-    binding.pry
+    mentor.update_location(params[:user][:location])
     mentor.profile_complete = true
     user.save
   end
@@ -31,7 +31,7 @@ class Api::V1::MentorsController < Api::V1::BaseController
   end
 
   def location_params
-    params.require(:user).permit(:city, :state, :country)
+    params.require(:user).permit(:location)
   end
 
   def census_params

--- a/app/controllers/api/v1/mentors_controller.rb
+++ b/app/controllers/api/v1/mentors_controller.rb
@@ -6,7 +6,7 @@ class Api::V1::MentorsController < Api::V1::BaseController
   end
 
   def show
-    mentor = Mentor.find_or_create_by(user: params[:id])
+    mentor = Mentor.find_or_create_by(user_id: params[:id])
 
     render json: mentor.profile
   end
@@ -15,7 +15,7 @@ class Api::V1::MentorsController < Api::V1::BaseController
     CensusService.new(current_user.token).update_census(current_user.census_id, census_params)
     user = User.find(params[:id])
     user.update(user_params)
-    mentor = Mentor.find_or_create_by(user: user)
+    mentor = Mentor.find_or_create_by(user_id: params[:id])
     mentor.update(mentor_params)
     mentor.profile_complete = true
     user.save
@@ -29,7 +29,6 @@ class Api::V1::MentorsController < Api::V1::BaseController
 
   def mentor_params
     params.require(:user).permit(:company, :position, :location, :expertise, :active, :gender)
-    .merge!({timezone_id: 1})
   end
 
   def census_params

--- a/app/controllers/api/v1/mentors_controller.rb
+++ b/app/controllers/api/v1/mentors_controller.rb
@@ -7,16 +7,15 @@ class Api::V1::MentorsController < Api::V1::BaseController
 
   def show
     mentor = Mentor.find_or_create_by(user_id: params[:id])
-
     render json: mentor.profile
   end
 
   def update
-    CensusService.new(current_user.token).update_census(current_user.census_id, census_params)
     user = User.find(params[:id])
     user.update(user_params)
     mentor = Mentor.find_or_create_by(user_id: params[:id])
     mentor.update(mentor_params)
+    binding.pry
     mentor.profile_complete = true
     user.save
   end
@@ -28,7 +27,11 @@ class Api::V1::MentorsController < Api::V1::BaseController
   end
 
   def mentor_params
-    params.require(:user).permit(:company, :position, :location, :expertise, :active, :gender)
+    params.require(:user).permit(:company, :position, :expertise, :active, :gender)
+  end
+
+  def location_params
+    params.require(:user).permit(:city, :state, :country)
   end
 
   def census_params

--- a/app/controllers/api/v1/mentors_controller.rb
+++ b/app/controllers/api/v1/mentors_controller.rb
@@ -15,9 +15,7 @@ class Api::V1::MentorsController < Api::V1::BaseController
     user.update(user_params)
     mentor = Mentor.find_or_create_by(user_id: params[:id])
     mentor.update(mentor_params)
-    mentor.update_location(params[:user][:location])
-    mentor.profile_complete = true
-    user.save
+    # mentor.profile_complete = true
   end
 
   private
@@ -27,11 +25,7 @@ class Api::V1::MentorsController < Api::V1::BaseController
   end
 
   def mentor_params
-    params.require(:user).permit(:company, :position, :expertise, :active, :gender)
-  end
-
-  def location_params
-    params.require(:user).permit(:location)
+    params.require(:user).permit(:company, :position, :expertise, :active, :gender, :location)
   end
 
   def census_params

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -4,10 +4,9 @@ class Location < ApplicationRecord
     loc = Location.find_by(search_name: search_name)
     if loc.nil?
       geocode = Geokit::Geocoders::GoogleGeocoder.geocode(search_name)
-      unless geocode.full_address.nil?
-        timezone = Timezone.lookup(geocode.lat, geocode.lng)
-        loc = Location.create(search_name: search_name, full_name: geocode.full_address, timezone_name: timezone.name)
-      end
+      return nil if geocode.full_address.nil? || geocode.full_address.empty?
+      timezone = Timezone.lookup(geocode.lat, geocode.lng)
+      loc = Location.create(search_name: search_name, full_name: geocode.full_address, timezone_name: timezone.name)
     end
     loc
   end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -1,0 +1,14 @@
+class Location < ApplicationRecord
+
+  def self.find_by_search_name_or_parse(search_name)
+    loc = Location.find_by(search_name: search_name)
+    if loc.nil?
+      geocode = Geokit::Geocoders::GoogleGeocoder.geocode(search_name)
+      unless geocode.full_address.nil?
+        timezone = Timezone.lookup(geocode.lat, geocode.lng)
+        loc = Location.create(search_name: search_name, full_name: geocode.full_address, timezone_name: timezone.name)
+      end
+    end
+    loc
+  end
+end

--- a/app/models/mentor.rb
+++ b/app/models/mentor.rb
@@ -23,7 +23,7 @@ class Mentor < ApplicationRecord
     attr_list = [
       :account_url, :active, :avatar, :bio, :company,
       :email, :expertise, :first_name, :gender, :last_name,
-      :location, :position, :profile_complete, :slack, :state
+      :location, :position, :profile_complete, :slack
     ]
 
     attr_list.reduce({}) do |profile, attr|
@@ -32,7 +32,9 @@ class Mentor < ApplicationRecord
   end
 
   def determine_timezone
+    return if location.nil?
     loc = Location.find_by_search_name_or_parse(location)
+    return if loc.nil?
     assign_attributes(location: loc.full_name, timezone_name: loc.timezone_name)
   end
 end

--- a/app/models/mentor.rb
+++ b/app/models/mentor.rb
@@ -5,6 +5,8 @@ class Mentor < ApplicationRecord
   has_many :mentor_skills
   has_many :skills, through: :mentor_skills
 
+  before_save :determine_timezone
+
   delegate :avatar,
            :first_name,
            :last_name,
@@ -17,14 +19,11 @@ class Mentor < ApplicationRecord
            :account_url,
            :last_active, to: :user
 
-  attr_writer :location
-
-
   def profile
     attr_list = [
-      :account_url, :active, :avatar, :bio, :company, :city,
-      :country, :email, :expertise, :first_name, :gender,
-      :last_name, :position, :profile_complete, :slack, :state
+      :account_url, :active, :avatar, :bio, :company,
+      :email, :expertise, :first_name, :gender, :last_name,
+      :location, :position, :profile_complete, :slack, :state
     ]
 
     attr_list.reduce({}) do |profile, attr|
@@ -32,9 +31,8 @@ class Mentor < ApplicationRecord
     end
   end
 
-  def define_location
-    binding.pry
-    loc = Geokit::Geocoders::GoogleGeocoder.geocode(location)
-    loc.precision == 'unknown' ? nil : Timezone.lookup(loc.lat, loc.lng)
+  def determine_timezone
+    loc = Location.find_by_search_name_or_parse(location)
+    assign_attributes(location: loc.full_name, timezone_name: loc.timezone_name)
   end
 end

--- a/app/models/mentor.rb
+++ b/app/models/mentor.rb
@@ -30,4 +30,9 @@ class Mentor < ApplicationRecord
     end
   end
 
+  def determine_timezone
+    loc = Geokit::Geocoders::GoogleGeocoder.geocode(location)
+    loc.precision == 'unknown' ? nil : Timezone.lookup(loc.lat, loc.lng)
+  end
+
 end

--- a/app/models/mentor.rb
+++ b/app/models/mentor.rb
@@ -1,5 +1,5 @@
 class Mentor < ApplicationRecord
-  belongs_to :timezone
+  # belongs_to :timezone
   belongs_to :user
 
   has_many :mentor_skills

--- a/app/models/mentor.rb
+++ b/app/models/mentor.rb
@@ -17,12 +17,14 @@ class Mentor < ApplicationRecord
            :account_url,
            :last_active, to: :user
 
+  attr_writer :location
+
 
   def profile
     attr_list = [
-      :account_url, :active, :avatar, :bio, :company, :email,
-      :expertise, :first_name, :gender, :last_name, :location,
-      :position, :profile_complete, :slack
+      :account_url, :active, :avatar, :bio, :company, :city,
+      :country, :email, :expertise, :first_name, :gender,
+      :last_name, :position, :profile_complete, :slack, :state
     ]
 
     attr_list.reduce({}) do |profile, attr|
@@ -30,9 +32,9 @@ class Mentor < ApplicationRecord
     end
   end
 
-  def determine_timezone
+  def define_location
+    binding.pry
     loc = Geokit::Geocoders::GoogleGeocoder.geocode(location)
     loc.precision == 'unknown' ? nil : Timezone.lookup(loc.lat, loc.lng)
   end
-
 end

--- a/app/models/mentor.rb
+++ b/app/models/mentor.rb
@@ -1,5 +1,4 @@
 class Mentor < ApplicationRecord
-  # belongs_to :timezone
   belongs_to :user
 
   has_many :mentor_skills

--- a/app/models/timezone.rb
+++ b/app/models/timezone.rb
@@ -1,5 +1,0 @@
-class Timezone < ApplicationRecord
-  validates :name, presence: true
-
-  has_many :mentors
-end

--- a/app/serializers/mentor_serializer.rb
+++ b/app/serializers/mentor_serializer.rb
@@ -1,40 +1,31 @@
 class MentorSerializer < ActiveModel::Serializer
   attributes :id,
-             :avatar,
-             :name,
-             :email,
-             :phone,
-             :slack,
-             :location,
-             :timezone_id,
-             :bio,
-             :expertise,
-             :company,
-             :position,
-             :last_active,
-             :first_name,
-             :last_name,
              :active,
+             :avatar,
+             :bio,
+             :company,
+             :email,
+             :expertise,
+             :first_name,
              :gender,
-             :timezone
+             :last_active,
+             :last_name,
+             :location,
+             :name,
+             :phone,
+             :position,
+             :slack,
+             :timezone_name
 
   def last_active
     object.updated_at.strftime("%A %d %b %Y %l:%M %p")
     # object.last_active.strftime("%A %d %b %Y %l:%M %p")
   end
 
-
   def name
     first = object.first_name
     last = object.last_name
     "#{first} #{last}"
-  end
-  def timezone
-    object.timezone.name
-  end
-
-  def timezone
-    object.timezone.name
   end
 
   def gender

--- a/config/initializers/timezone.rb
+++ b/config/initializers/timezone.rb
@@ -1,0 +1,7 @@
+Timezone::Lookup.config(:geonames) do |c|
+  c.username = ENV['GEONAMES_USERNAME']
+end
+
+Timezone::Lookup.config(:google) do |c|
+  c.api_key = ENV['GOOGLE_API_KEY']
+end

--- a/db/migrate/20170531171559_replace_location_with_city_state_country.rb
+++ b/db/migrate/20170531171559_replace_location_with_city_state_country.rb
@@ -1,8 +1,0 @@
-class ReplaceLocationWithCityStateCountry < ActiveRecord::Migration[5.0]
-  def change
-    remove_column :mentors, :location, :string
-    add_column :mentors, :city, :string
-    add_column :mentors, :state, :string
-    add_column :mentors, :country, :string
-  end
-end

--- a/db/migrate/20170531171559_replace_location_with_city_state_country.rb
+++ b/db/migrate/20170531171559_replace_location_with_city_state_country.rb
@@ -1,0 +1,8 @@
+class ReplaceLocationWithCityStateCountry < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :mentors, :location, :string
+    add_column :mentors, :city, :string
+    add_column :mentors, :state, :string
+    add_column :mentors, :country, :string
+  end
+end

--- a/db/migrate/20170531173054_remove_timezone_reference_from_mentors.rb
+++ b/db/migrate/20170531173054_remove_timezone_reference_from_mentors.rb
@@ -1,0 +1,5 @@
+class RemoveTimezoneReferenceFromMentors < ActiveRecord::Migration[5.0]
+  def change
+    remove_reference :mentors, :timezone, index: true, foreign_key: true
+  end
+end

--- a/db/migrate/20170531173244_add_timezone_to_mentors.rb
+++ b/db/migrate/20170531173244_add_timezone_to_mentors.rb
@@ -1,5 +1,5 @@
 class AddTimezoneToMentors < ActiveRecord::Migration[5.0]
   def change
-    add_column :mentors, :timezone, :string
+    add_column :mentors, :timezone_name, :string
   end
 end

--- a/db/migrate/20170531173244_add_timezone_to_mentors.rb
+++ b/db/migrate/20170531173244_add_timezone_to_mentors.rb
@@ -1,0 +1,5 @@
+class AddTimezoneToMentors < ActiveRecord::Migration[5.0]
+  def change
+    add_column :mentors, :timezone, :string
+  end
+end

--- a/db/migrate/20170601043249_create_locations.rb
+++ b/db/migrate/20170601043249_create_locations.rb
@@ -1,0 +1,9 @@
+class CreateLocations < ActiveRecord::Migration[5.0]
+  def change
+    create_table :locations do |t|
+      t.string :search_name
+      t.string :full_name
+      t.string :timezone_name
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170531173244) do
+ActiveRecord::Schema.define(version: 20170601043249) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "locations", force: :cascade do |t|
+    t.string "search_name"
+    t.string "full_name"
+    t.string "timezone_name"
+  end
 
   create_table "mentor_skills", force: :cascade do |t|
     t.integer "skill_id"
@@ -24,6 +30,7 @@ ActiveRecord::Schema.define(version: 20170531173244) do
 
   create_table "mentors", force: :cascade do |t|
     t.string   "expertise"
+    t.string   "location"
     t.string   "company"
     t.string   "position"
     t.integer  "user_id"
@@ -32,10 +39,7 @@ ActiveRecord::Schema.define(version: 20170531173244) do
     t.boolean  "active",           default: false
     t.boolean  "profile_complete", default: false
     t.string   "gender"
-    t.string   "city"
-    t.string   "state"
-    t.string   "country"
-    t.string   "timezone"
+    t.string   "timezone_name"
     t.index ["user_id"], name: "index_mentors_on_user_id", using: :btree
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170526031531) do
+ActiveRecord::Schema.define(version: 20170531173244) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,9 +23,7 @@ ActiveRecord::Schema.define(version: 20170526031531) do
   end
 
   create_table "mentors", force: :cascade do |t|
-    t.integer  "timezone_id"
     t.string   "expertise"
-    t.string   "location"
     t.string   "company"
     t.string   "position"
     t.integer  "user_id"
@@ -34,7 +32,10 @@ ActiveRecord::Schema.define(version: 20170526031531) do
     t.boolean  "active",           default: false
     t.boolean  "profile_complete", default: false
     t.string   "gender"
-    t.index ["timezone_id"], name: "index_mentors_on_timezone_id", using: :btree
+    t.string   "city"
+    t.string   "state"
+    t.string   "country"
+    t.string   "timezone"
     t.index ["user_id"], name: "index_mentors_on_user_id", using: :btree
   end
 
@@ -66,7 +67,6 @@ ActiveRecord::Schema.define(version: 20170526031531) do
     t.integer  "census_id"
   end
 
-  add_foreign_key "mentors", "timezones"
   add_foreign_key "mentors", "users"
   add_foreign_key "students", "users"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,16 +5,8 @@ require './app/models/timezone.rb'
 class Seed
 
   def start
-    create_timezones
     find_mentors
     skills
-  end
-
-  def create_timezones
-    ['Pacific', 'Mountain', 'Central', 'Eastern'].each do |location|
-      Timezone.create!(name: location)
-      puts "Created time zone: #{location}!"
-    end
   end
 
   def get_all_census_users
@@ -29,7 +21,6 @@ class Seed
   end
 
   def create_user(user)
-    timezone = Timezone.find(rand(1..4))
     genders = ["Male", "Female", "Other"]
     accepting_mentees = [true, false]
     new_user = User.create!(
@@ -41,9 +32,10 @@ class Seed
     )
     puts "Created user: #{user[:first_name]}!"
     new_user.create_mentor!(
-      timezone_id: timezone.id,
       expertise: "Enter your expertise here",
-      location: "location",
+      city: 'Denver',
+      state: 'CO',
+      country: 'USA',
       company: "Company",
       position: "Position",
       gender: genders.sample,

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,6 +6,7 @@ class Seed
 
   def start
     find_mentors
+    create_locations
     skills
   end
 
@@ -18,6 +19,14 @@ class Seed
     get_all_census_users.each do |user|
       create_user(user) if user[:roles].any?{|role| role[:name] == "mentor"}
     end
+  end
+
+  def create_locations
+    Location.create(
+      search_name: 'Denver, CO, USA',
+      full_name: 'Denver, CO, USA',
+      timezone_name: 'America/Denver'
+    )
   end
 
   def create_user(user)
@@ -33,9 +42,7 @@ class Seed
     puts "Created user: #{user[:first_name]}!"
     new_user.create_mentor!(
       expertise: "Enter your expertise here",
-      city: 'Denver',
-      state: 'CO',
-      country: 'USA',
+      location: 'Denver, CO, USA',
       company: "Company",
       position: "Position",
       gender: genders.sample,

--- a/spec/factories/locations.rb
+++ b/spec/factories/locations.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :location do
+    
+  end
+end

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Location, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
This branch updates the mentor create/edit page to make the location field dynamic on the back end.

- The user enters their location with the following format: _City, State, Country_
- On the backend, the Google Timezone API finds the location matching the user input
     - Google's search is case insensitive and is very intuitive. I haven't been able to break it yet. So as long as the user follows the specified format, it should always find their location.
     - NOTE: Because there is a daily limit on the number of API calls, I created a 'locations' table to hold the relevant data from previous queries. I'm not super attached to this way of doing things, so I'm open to any other suggestions. Caching, maybe?
- Using the longitude and latitude from the API search, the app finds the corresponding timezone with the Timezone gem.
- I believe that all functionality is working. I tested the edit page and the mentor page.
 